### PR TITLE
Added MOUNTPOINTS environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+May 30, 2017
+
+ADDED
+* Code support and documentation for over-riding list of filesystem mounts created in a container
+* This changelog
+
+CHANGED
+* Nothing
+
+REMOVED
+* Nothing
+

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ No need to download anything from this repository! Simply type:
 
 Replace `D:\host\path\where\to\ouptut\singularity\image` with a path on the host filesystem where your Singularity image will be created. Replace `ubuntu:14.04` with the docker image name you wish to convert (it will be pulled from Docker Hub if it does not exist on your host system).
 
+Pass in custom mount points as an evironment variable `-e MOUNTPOINTS=/home /work /scratch` to override the defaults that ship with `docker2singularity`. This is handy for adding shared filesystems that are specific to your local Singularity-powered HPC system. 
+
 `docker2singularity` uses the Docker daemon located on the host system. It will access the Docker image cache from the host system avoiding having to redownload images that are already present locally.
 
 ## Tips for making Docker images compatible with Singularity

--- a/docker2singularity.sh
+++ b/docker2singularity.sh
@@ -155,11 +155,9 @@ singularity exec --writable --contain $new_container_name /bin/sh -c "mkdir -p $
 
 # making sure that any user can read and execute everything in the container
 echo "(7/9) Fixing permissions..."
-echo "7.1"
 singularity exec --writable --contain $new_container_name /bin/sh -c "find /* -maxdepth 0 -not -path '/dev*' -not -path '/proc*' -not -path '/sys*' -exec chmod a+r -R '{}' \;"
 
 # assume Builroot container and use BusyBox find
-echo "7.2"
 singularity exec --writable --contain $new_container_name /bin/sh -c "find / \( -type f -o -type d \) -perm -u+x ! -perm -o+x ! -path '/dev*' ! -path '/proc*' ! -path '/sys*' -exec chmod a+x '{}' \;"
 
 echo "(8/9) Stopping and removing the container..."


### PR DESCRIPTION
Supports override of container mountpoints by specifying (for example) `-e MOUNTPOINTS=/home /work /scratch` when `tacc/docker2singularity` is run 